### PR TITLE
Remove Google+ Link

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -76,7 +76,6 @@
           <div class="social-share-buttons">
             <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fpanopticlick.eff.org%2F&amp;display=popup">Share on Facebook</a>
             <a href="https://twitter.com/home?status=Worried%20about%20online%20tracking?%20Find%20out%20how%20vulnerable%20you%20really%20are%20with%20Panopticlick%20https%3A//panopticlick.eff.org&amp;related=eff">Share on Twitter</a>
-            <a href="https://plus.google.com/share?url=https://panopticlick.eff.org">Share on Google+</a>
           </div>
 
           <a href="https://www.eff.org/"><img class="logo" src="static/images/logo.svg" alt="EFF logo"></img></a>


### PR DESCRIPTION
Google+ has been shut down, so the share link can probably be removed.